### PR TITLE
Specify what is a valid query

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :paths ["src"]
 
  :deps {org.clojure/core.logic {:mvn/version "0.8.11"}
-        org.clojure/clojure {:mvn/version "1.10.0-beta8"}}
+        org.clojure/clojure {:mvn/version "1.10.0"}}
 
  :aliases {:dev {:extra-paths ["test"]
                  :extra-deps {org.clojure/test.check {:mvn/version "0.10.0-alpha3"}

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :url "https://github.com/Swirrl/matcha"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.10.0-beta8"]
+  :dependencies [[org.clojure/clojure "1.10.0"]
                  [org.clojure/core.logic "0.8.11"]]
 
   :profiles {:dev {:dependencies [[grafter "0.11.4"]]}}

--- a/test/grafter/matcha/alpha_test.clj
+++ b/test/grafter/matcha/alpha_test.clj
@@ -1,6 +1,6 @@
 (ns grafter.matcha.alpha-test
   (:require [clojure.test :refer :all]
-            [grafter.matcha.alpha :refer :all]
+            [grafter.matcha.alpha :as m :refer :all]
             [grafter.vocabularies.core :refer [prefixer]]
             [grafter.vocabularies.foaf :refer [foaf:knows]]
             [grafter.vocabularies.rdf :refer [rdfs:label]]
@@ -241,3 +241,74 @@
                                [?p2 rdfs:label ?name]])]
     (is (= ["Martin" "Katie"]
            (ricks-friends lotsa-data)))))
+
+(defmacro throws? [ex-type & body]
+  `(is (try
+         ~@body
+         false
+         (catch clojure.lang.ExceptionInfo e#
+           (= (-> e# ex-data :type) ~ex-type)))))
+
+(deftest runtime-validation-test
+
+  ;; select validation
+  (letfn [(selectq [uri]
+            (select
+             [?name]
+             [[uri foaf:knows ?p]
+              [?p rdfs:label ?name]]))]
+
+    ;; valid syntax doesn't throw
+    (is (= ["Martin" "Katie"]
+           ((selectq rick) friends)))
+
+    ;; literal set throws
+    (throws? ::m/select-validation-error ((selectq #{rick}) friends))
+
+    ;; bound arg set throws
+    (throws? ::m/select-validation-error (let [arg #{rick}] ((selectq arg) friends))))
+
+  ;; construct validation
+  (letfn [(constructq [uri]
+            (construct
+             {:foaf/knows ?name}
+             [[uri foaf:knows ?p]
+              [?p rdfs:label ?name]]))]
+
+    ;; valid syntax doesn't throw
+    (is (= [#:foaf{:knows "Martin"} #:foaf{:knows "Katie"}]
+           ((constructq rick) friends)))
+
+    ;; s-expressions in bgps don't throw
+    (is (= [#:foaf{:knows "Martin"} #:foaf{:knows "Katie"}]
+           ((construct {:foaf/knows ?name}
+              [[(identity (identity rick)) foaf:knows ?p]
+               [?p rdfs:label ?name]])
+            friends)))
+
+    ;; more complex s-expressions in bgps don't throw
+    (is (= [#:foaf{:knows "Martin"} #:foaf{:knows "Katie"}]
+           ((construct {:foaf/knows ?name}
+              [[(((fn [_] (fn [x] x)) 1) rick) foaf:knows ?p]
+               [?p rdfs:label ?name]])
+            friends)))
+
+    ;; literal set throws
+    (throws? ::m/construct-validation-error ((constructq #{rick}) friends))
+
+    ;; bound arg set throws
+    (throws? ::m/construct-validation-error (let [arg #{rick}] ((constructq arg) friends))))
+
+  ;; ask validation
+  (letfn [(askq [uri]
+            (ask [[uri foaf:knows ?p]
+                  [?p rdfs:label ?name]]))]
+
+    ;; valid syntax doesn't throw
+    (is ((askq rick) friends))
+
+    ;; literal set throws
+    (throws? ::m/ask-validation-error ((askq #{rick}) friends))
+
+    ;; bound arg set throws
+    (throws? ::m/ask-validation-error (let [arg #{rick}] ((askq arg) friends)))))


### PR DESCRIPTION
Add a fairly loose spec for the syntax of the API's macros, and validation for the query data at runtime. 

This prevents users calling the API with invalid syntax, which may diverge or return unexpected results.

Fixes: #12 