### PR TITLE
Add syntax specs and allow passing of db directly via a new macro arity

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :paths ["src"]
 
  :deps {org.clojure/core.logic {:mvn/version "0.8.11"}
-        org.clojure/clojure {:mvn/version "1.10.0-beta8"}}
+        org.clojure/clojure {:mvn/version "1.10.0"}}
 
  :aliases {:dev {:extra-paths ["test"]
                  :extra-deps {org.clojure/test.check {:mvn/version "0.10.0-alpha3"}

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :url "https://github.com/Swirrl/matcha"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.10.0-beta8"]
+  :dependencies [[org.clojure/clojure "1.10.0"]
                  [org.clojure/core.logic "0.8.11"]]
 
   :profiles {:dev {:dependencies [[grafter "0.11.4"]]}}

--- a/src/grafter/matcha/alpha.clj
+++ b/src/grafter/matcha/alpha.clj
@@ -95,7 +95,7 @@
     (and (sequential? bgps)
          (every? valid-bgp? bgps))))
 
-(defn validate-bgps [bgps error-message error-data]
+(defn- validate-bgps* [bgps error-message error-data]
   (let [quote-qvars (partial walk/postwalk #(if (query-var? %) `(quote ~%) %))]
     `(let [bgps# ~(quote-qvars bgps)]
        (when-not (valid-bgps? bgps#)
@@ -103,42 +103,48 @@
                          (merge {:bgps bgps#}
                                 ~(quote-qvars error-data))))))))
 
+(defn- generate-solutions* [project-vars syms query-patterns db-or-idx]
+  `(let [idx# (index-if-necessary ~db-or-idx)]
+     (pldb/with-db idx#
+       (l/run* ~project-vars
+         (fresh ~syms
+           ~@query-patterns)))))
+
 (defmacro select
   ([bgps]
    `(select ~(find-vars bgps) ~bgps))
   ([project-vars bgps]
+   `(fn [db-or-idx#]
+      (select ~project-vars ~bgps db-or-idx#)))
+  ([project-vars bgps db-or-idx]
    (let [pvar? (set project-vars)
-         syms (vec (->> (find-vars bgps)
-                        (remove pvar?)))
-         query-patterns (map (fn [[s p o]]
-                               `(triple ~s ~p ~o)) bgps)]
-
-     `(fn [db-or-idx#]
-        ~(validate-bgps bgps
+         syms (vec (->> (find-vars bgps) (remove pvar?)))
+         query-patterns (map (fn [[s p o]] `(triple ~s ~p ~o)) bgps)]
+     `(do
+        ~(validate-bgps* bgps
                         "Invalid data syntax passed to `select` query at runtime"
                         {:type ::select-validation-error
                          :project-vars project-vars})
-        (let [idx# (index-if-necessary db-or-idx#)]
-          (pldb/with-db idx#
-            (l/run* ~project-vars
-              (fresh ~syms
-                ~@query-patterns))))))))
+        ~(generate-solutions* project-vars syms query-patterns db-or-idx)))))
 
-(s/fdef select
-  :args (s/or :ary-1 (s/cat :bgps ::bgps)
-              :ary-2 (s/cat :project-vars (s/coll-of query-var?)
-                            :bgps ::bgps)))
+(let [ary-1 (s/cat :bgps ::bgps)
+      ary-2 (s/cat :project-vars (s/coll-of query-var?) :ary-1 ary-1)]
+  (s/fdef select
+    :args (s/or
+           :ary-1 ary-1
+           :ary-2 ary-2
+           :ary-3 (s/cat :ary-2 ary-2 :db any?))))
 
 (defmacro select-1
   ([bgps]
    `(select-1 ~(find-vars bgps) ~bgps))
   ([project-vars bgps]
-   `(fn [db#]
-      (first ((select ~project-vars ~bgps) db#)))))
+   `(comp first (select ~project-vars ~bgps)))
+  ([project-vars bgps db]
+   `(first (select ~project-vars ~bgps ~db))))
 
 (defn find-vars-in-tree [tree]
   (filterv query-var? (tree-seq coll? seq tree)))
-
 
 (defn unify-solutions [projected-vars solutions]
   (map (fn [s]
@@ -185,53 +191,58 @@
     solutions))
 
 (defmacro construct
-  [construct-pattern bgps]
-  (let [pvars (find-vars-in-tree construct-pattern)
-        syms (vec (->> (find-vars bgps)
-                       (remove (set pvars))))
-        query-patterns (map (fn [[s p o]]
-                              `(triple ~s ~p ~o)) bgps)
-        pvarvec (vec pvars)]
+  ([construct-pattern bgps]
+   `(fn [db-or-idx#]
+      (construct ~construct-pattern ~bgps db-or-idx#)))
+  ([construct-pattern bgps db-or-idx]
+   (let [pvars (find-vars-in-tree construct-pattern)
+         syms (vec (->> (find-vars bgps) (remove (set pvars))))
+         query-patterns (map (fn [[s p o]] `(triple ~s ~p ~o)) bgps)
+         pvarvec (vec pvars)]
+     `(do
+        ~(validate-bgps* bgps
+                        "Invalid data syntax passed to `construct` query at runtime"
+                        {:type ::construct-validation-error
+                         :construct-pattern construct-pattern})
+        (let [solutions# ~(generate-solutions* pvarvec syms query-patterns db-or-idx)
+              ;; create a sequence of {?var :value} binding maps for
+              ;; each solution.
+              vars->vals# (unify-solutions (quote ~pvarvec) solutions#)
 
-    `(fn [db-or-idx#]
-       ~(validate-bgps bgps
-                       "Invalid data syntax passed to `construct` query at runtime"
-                       {:type ::construct-validation-error
-                        :construct-pattern construct-pattern})
-       (let [idx# (index-if-necessary db-or-idx#)
-             solutions# (pldb/with-db idx#
-                          (l/run* ~pvarvec
-                            (fresh ~syms
-                              ~@query-patterns)))
-             ;; create a sequence of {?var :value} binding maps for
-             ;; each solution.
-             vars->vals# (unify-solutions (quote ~pvarvec) solutions#)
+              subj-maps# (replace-vars-with-vals ~(quote-query-vars pvarvec construct-pattern)
+                                                 vars->vals#)
 
-             subj-maps# (replace-vars-with-vals ~(quote-query-vars pvarvec construct-pattern)
-                                                vars->vals#)
+              grouped# (group-subjects subj-maps#)]
+          grouped#)))))
 
-             grouped# (group-subjects subj-maps#)]
-         grouped#))))
+(let [ary-2 (s/cat :construct-pattern any? :bgps ::bgps)
+      ary-3 (s/cat :ary-2 ary-2 :db any?)]
+  (s/fdef construct
+    :args (s/or :ary-2 ary-2
+                :ary-3 ary-3)))
 
-(s/fdef construct
-  :args (s/cat :construct-pattern any? :bgps ::bgps))
+(defmacro construct-1
+  ([construct-pattern bgps]
+   `(comp first (construct ~construct-pattern ~bgps)))
+  ([construct-pattern bgps db]
+   `(first (construct ~construct-pattern ~bgps ~db))))
 
-(defmacro construct-1 [construct-pattern bgps]
-  `(fn [db#]
-     (first ((construct ~construct-pattern ~bgps) db#))))
-
-(defmacro ask [bgps]
-  `(let [f# (select ~bgps)]
-    (fn [db#]
-      ~(validate-bgps bgps
-                      "Invalid data syntax passed to `ask` query at runtime"
-                      {:type ::ask-validation-error})
-      (if (seq (f# db#))
+(defmacro ask
+  ([bgps]
+   `(fn [db#] (ask ~bgps db#)))
+  ([bgps db]
+   `(do
+      ~(validate-bgps* bgps
+                       "Invalid data syntax passed to `ask` query at runtime"
+                       {:type ::ask-validation-error})
+      (if (seq (select ~(find-vars bgps) ~bgps ~db))
         true
         false))))
 
-(s/fdef ask
-  :args (s/cat :bgps ::bgps))
+(let [ary-1 (s/cat :bgps ::bgps)]
+  (s/fdef ask
+    :args (s/or :ary-1 ary-1
+                :ary-2 (s/cat :ary-1 ary-1 :db any?))))
 
 (defn merge-dbs
   "Merges all supplied Matcha databases together into one.  Any

--- a/test/grafter/matcha/alpha_test.clj
+++ b/test/grafter/matcha/alpha_test.clj
@@ -332,7 +332,10 @@
 
     ;; bound arg set throws
     (throws? ::m/ask-validation-error (let [arg #{rick}] ((askq-1 arg) friends)))
-    (throws? ::m/ask-validation-error (let [arg #{rick}] (askq-2 arg friends)))))
+    (throws? ::m/ask-validation-error (let [arg #{rick}] (askq-2 arg friends)))
+
+    ;; no ?qvars are OK
+    (is (let [col-uri rick] (m/ask [[col-uri foaf:knows martin]] friends)))))
 
 (deftest immediate-and-function-macro-arities-equiv
   (let [uri rick]

--- a/test/grafter/matcha/alpha_test.clj
+++ b/test/grafter/matcha/alpha_test.clj
@@ -1,6 +1,6 @@
 (ns grafter.matcha.alpha-test
   (:require [clojure.test :refer :all]
-            [grafter.matcha.alpha :refer :all]
+            [grafter.matcha.alpha :as m :refer :all]
             [grafter.vocabularies.core :refer [prefixer]]
             [grafter.vocabularies.foaf :refer [foaf:knows]]
             [grafter.vocabularies.rdf :refer [rdfs:label]]
@@ -241,3 +241,74 @@
                                [?p2 rdfs:label ?name]])]
     (is (= ["Martin" "Katie"]
            (ricks-friends lotsa-data)))))
+
+(defmacro throws? [ex-type & body]
+  `(is (try
+         ~@body
+         false
+         (catch clojure.lang.ExceptionInfo e#
+           (= (-> e# ex-data :type) ~ex-type)))))
+
+(deftest runtime-validation-test
+
+  ;; select validation
+  (letfn [(selectq [uri]
+            (select
+             [?name]
+             [[uri foaf:knows ?p]
+              [?p rdfs:label ?name]]))]
+
+    ;; valid syntax doesn't throw
+    (is (= ["Martin" "Katie"]
+           ((selectq rick) friends)))
+
+    ;; literal set throws
+    (throws? ::m/select-validation-error ((selectq #{rick}) friends))
+
+    ;; bound arg set throws
+    (throws? ::m/select-validation-error (let [arg #{rick}] ((selectq arg) friends))))
+
+  ;; construct validation
+  (letfn [(constructq [uri]
+            (construct
+             {:foaf/knows ?name}
+             [[uri foaf:knows ?p]
+              [?p rdfs:label ?name]]))]
+
+    ;; valid syntax doesn't throw
+    (is (= [#:foaf{:knows "Martin"} #:foaf{:knows "Katie"}]
+           ((constructq rick) friends)))
+
+    ;; s-expressions in bgps don't throw
+    (is (= [#:foaf{:knows "Martin"} #:foaf{:knows "Katie"}]
+           ((construct {:foaf/knows ?name}
+              [[(identity (identity rick)) foaf:knows ?p]
+               [?p rdfs:label ?name]])
+            friends)))
+
+    ;; more complex s-expressions in bgps don't throw
+    (is (= [#:foaf{:knows "Martin"} #:foaf{:knows "Katie"}]
+           ((construct {:foaf/knows ?name}
+              [[(((fn [_] (fn [x] x)) 1) rick) foaf:knows ?p]
+               [?p rdfs:label ?name]])
+            friends)))
+
+    ;; literal set throws
+    (throws? ::m/construct-validation-error ((constructq #{rick}) friends))
+
+    ;; bound arg set throws
+    (throws? ::m/construct-validation-error (let [arg #{rick}] ((constructq arg) friends))))
+
+  ;; ask validation
+  (letfn [(askq [uri]
+            (ask [[uri foaf:knows ?p]
+                  [?p rdfs:label ?name]]))]
+
+    ;; valid syntax doesn't throw
+    (is ((askq rick) friends))
+
+    ;; literal set throws
+    (throws? ::m/ask-validation-error ((askq #{rick}) friends))
+
+    ;; bound arg set throws
+    (throws? ::m/ask-validation-error (let [arg #{rick}] ((askq arg) friends)))))


### PR DESCRIPTION
Based on #13 (so could use that merged first).

New arity for `select`/`construct` to simplify use.

Add new 3-ary arity for select and construct macros so that the `db` can be passed direcly to the macro for immediate execution.

NOTE: the last commit is the diff from #13.