### PR TITLE
Feature/issue 11 support optional keyword

### DIFF
--- a/src/grafter/matcha/alpha.clj
+++ b/src/grafter/matcha/alpha.clj
@@ -248,13 +248,14 @@
 
   If called with 3 arguments, queries the `db-or-idx` directly, returning a
   sequence of results with the `?vars` in `project-vars` projected."
+  {:style/indent :defn}
   ([bgps]
    `(select ~(find-vars bgps) ~bgps))
   ([project-vars bgps]
    `(fn [db-or-idx#]
       (select ~project-vars ~bgps db-or-idx#)))
   ([project-vars bgps db-or-idx]
-   (solve* 'select {:project-vars project-vars} project-vars bgps db-or-idx)))
+   (solve* 'select &env project-vars bgps db-or-idx)))
 
 (s/fdef select
   :args (s/or
@@ -358,9 +359,8 @@
       (construct ~construct-pattern ~bgps db-or-idx#)))
   ([construct-pattern bgps db-or-idx]
    (let [pvars (find-vars-in-tree construct-pattern)
-         pvarvec (vec pvars)
-         err-data {:construct-pattern construct-pattern}]
-     `(->> ~(solve* 'construct err-data pvars bgps db-or-idx)
+         pvarvec (vec pvars)]
+     `(->> ~(solve* 'construct &env pvars bgps db-or-idx)
            ;; create a sequence of {?var :value} binding maps for
            ;; each solution.
            (unify-solutions (quote ~pvarvec))
@@ -422,7 +422,7 @@
   ([bgps]
    `(fn [db#] (ask ~bgps db#)))
   ([bgps db]
-   `(boolean (seq ~(solve* 'ask {} '[?_] bgps db)))))
+   `(boolean (seq ~(solve* 'ask &env '[?_] bgps db)))))
 
 (s/fdef ask
   :args (s/or :ary-1 (s/cat :bgps ::bgps)

--- a/src/grafter/matcha/alpha.clj
+++ b/src/grafter/matcha/alpha.clj
@@ -192,12 +192,17 @@
                   {:type ::invalid-bgp
                    :args invalid}))))))
 
+(defn- flat-coll? [c]
+  (or (sequential? c)
+      (set? c)
+      (nil? c)))
+
 (defn valid-values? [values-syms]
-  (let [invalid (into {} (remove (comp set? second) values-syms))]
+  (let [invalid (into {} (remove (comp flat-coll? second) values-syms))]
     (when (seq invalid)
       (throw
        (ex-info
-        (str "Invalid Argument: `values` bound arguments must be sets\n"
+        (str "Invalid Argument: `values` bound arguments must be sequential?, set? or nil?\n"
              (format "%s were not" (pr-str invalid)))
         {:type ::invalid-values
          :args invalid})))))

--- a/src/grafter/matcha/alpha.clj
+++ b/src/grafter/matcha/alpha.clj
@@ -71,6 +71,22 @@
       vars
       '[?_])))
 
+(defmacro values
+  "Binds a ?qvar binding to elements of a set inside the query. MUST be used
+  inside a (select|construct|ask|etc) query.
+
+  SYNTAX: (values binding bound-value)
+          binding: ?qvar
+          bound-value: any?
+
+  E.G.,
+  (let [subjects #{:a :b :c}]
+    (select [?s ?p ?o]
+      [[?s ?p ?o]
+       (values ?s subjects)]))"
+  [binding bound-value]
+  (assert nil "`values` used not in a query block"))
+
 (defn collection? [x]
   (instance? java.util.Collection x))
 

--- a/src/grafter/matcha/alpha.clj
+++ b/src/grafter/matcha/alpha.clj
@@ -87,6 +87,25 @@
   [binding bound-value]
   (assert nil "`values` used not in a query block"))
 
+(defmacro optional
+  "Makes a graph pattern optional. I.E., the pattern inside (optional [...]) is
+  optional, patterns outside are required. Can be arbitrarily nested. MUST be
+  used inside a (select|construct|ask|etc) query.
+
+  SYNTAX: (optional bgps)
+          bgps: ::bgps
+
+  E.G.,
+  (select [?o ?eman]
+    [[?person foaf:knows somebody]
+     (optional [[?o rdfs:label ?name]
+                (optional [[?name :name/backwards ?eman]
+                           (values ?name names)])])]
+    optional-friends)"
+  {:style/indent :defn ::clause true}
+  [bgps]
+  (assert nil "`optional` used not in a query block"))
+
 (defn collection? [x]
   (or (instance? java.util.Collection x)
       (map? x)))

--- a/src/grafter/matcha/alpha.clj
+++ b/src/grafter/matcha/alpha.clj
@@ -146,6 +146,23 @@
 
 (s/def ::bgps (s/coll-of ::pattern-row :kind vector?))
 
+(defn- parse-values [{:keys [binding bound]}]
+  `(l/membero ~binding (vec ~bound)))
+
+(declare parse-patterns)
+
+(defn- parse-clause [[type row]]
+  (case type
+    :values (parse-values row)))
+
+(defn- parse-pattern-row [[type row]]
+  (case type
+    :bgp `(triple ~@(s/unform ::bgp row))
+    :clause (parse-clause row)))
+
+(defn- parse-patterns [conformed]
+  (mapv parse-pattern-row conformed))
+
 (defmacro select
   "Query a `db-or-idx` with `bgps` patterns.
 

--- a/src/grafter/matcha/alpha.clj
+++ b/src/grafter/matcha/alpha.clj
@@ -62,11 +62,7 @@
        (string/starts-with? (str sym) "?")))
 
 (defn- find-vars [bgps]
-  (let [vars (->> bgps
-                     (mapcat identity)
-                     (filter query-var?)
-                     distinct
-                     vec)]
+  (let [vars (->> bgps flatten (filter query-var?) distinct vec)]
     (if (seq vars)
       vars
       '[?_])))

--- a/test/grafter/matcha/alpha_test.clj
+++ b/test/grafter/matcha/alpha_test.clj
@@ -374,3 +374,51 @@
     (let [v1 ((m/ask [[uri foaf:knows ?p] [?p rdfs:label ?name]]) friends)
           v2 (m/ask [[uri foaf:knows ?p] [?p rdfs:label ?name]] friends)]
       (is (= v1 v2)))))
+
+(deftest values-syntax-test
+  (is (= (let [people #{rick}]
+           (set
+            (select [?name]
+              [[?person foaf:knows ?o]
+               [?o rdfs:label ?name]
+               (values ?person people)]
+              friends)))
+         #{"Martin" "Katie"}))
+  (is (= (let [people #{rick katie}]
+           (set
+            (select [?name]
+              [[?person foaf:knows ?o]
+               [?o rdfs:label ?name]
+               (values ?person people)]
+              friends)))
+         #{"Martin" "Katie" "Julie"}))
+
+  (is (= (let [people #{rick katie}
+               names #{"Julie"}]
+           (set
+            (select [?name]
+              [[?person foaf:knows ?o]
+               (values ?person people)
+               [?o rdfs:label ?name]
+               (values ?name names)]
+              friends)))
+         #{"Julie"}))
+
+  (throws? ::m/invalid-values
+           (let [people rick]
+             (set
+              (select [?name]
+                [[?person foaf:knows ?o]
+                 [?o rdfs:label ?name]
+                 (values ?person people)]
+                friends)))
+           #{"Martin" "Katie" "Julie"})
+  (throws? ::m/invalid-values
+           (let [people [rick]]
+             (set
+              (select [?name]
+                [[?person foaf:knows ?o]
+                 [?o rdfs:label ?name]
+                 (values ?person people)]
+                friends)))
+           #{"Martin" "Katie" "Julie"}))

--- a/test/grafter/matcha/alpha_test.clj
+++ b/test/grafter/matcha/alpha_test.clj
@@ -414,8 +414,9 @@
                  (values ?person people)]
                 friends)))
            #{"Martin" "Katie" "Julie"})
+
   (throws? ::m/invalid-values
-           (let [people [rick]]
+           (let [people 1]
              (set
               (select [?name]
                 [[?person foaf:knows ?o]

--- a/test/grafter/matcha/alpha_test.clj
+++ b/test/grafter/matcha/alpha_test.clj
@@ -445,17 +445,49 @@
    (->Triple "Rick" :name/backwards "Kcir")])
 
 (deftest optional-syntax-test
-
   (testing "OPTIONAL behaviour"
-    (is (= (set
+    (let [tiny-db [[:a :triple :here]]]
+      (is (= #{[:a :triple :here]}
+             (set
+              (select [?s ?p ?o]
+                [(optional [[?s ?p ?o]])]
+                tiny-db))))
+
+      (is (empty?
+           (select [?s ?p ?o]
+             [(optional [[:do :not :match]])]
+             tiny-db)))
+
+      (is (= [[:a :triple :here]]
+             (select [?s ?p ?o]
+               [[?s ?p ?o]
+                (optional [[:optional :doesnt :match]
+                           [:but :required-pattern :does]])]
+               tiny-db)))
+
+      (is (= #{[:a :triple :here]}
+             (set
+              (select [?s ?p ?o]
+                [[?s ?p ?o]
+                 (optional [[?s ?p ?o]])]
+                tiny-db))))
+
+      (is (= #{[:a :triple :here]}
+             (set (select [?s ?p ?o]
+                    [(optional [[:optional :doesnt :match]
+                                [:but :other-optional :does]])
+                     (optional [[?s ?p ?o]])]
+                    tiny-db)))))
+
+    (is (= #{[julie "Not a robot"]}
+           (set
             (let [person katie]
               (select [?o ?name]
                 [[person foaf:knows ?o]
                  (optional [[?o rdfs:label ?name]])
                  (optional [[?o other:label ?name]])]
-                optional-friends)))
-           #{[julie "Not a robot"]}))
-    (is (= (set
+                optional-friends)))))
+
     (is (= #{[martin "Martin"] [katie "Katie"]}
            (set
             (let [person rick]
@@ -489,7 +521,8 @@
                 optional-friends))))))
 
   (testing "How about some optionals in your optionals?"
-    (is (= (set
+    (is (= #{[martin "Nitram"] [katie '_0] [julie '_0]}
+           (set
             (let [people #{rick katie}
                   names  #{"Martin"}]
               (select [?o ?eman]

--- a/test/grafter/matcha/alpha_test.clj
+++ b/test/grafter/matcha/alpha_test.clj
@@ -267,12 +267,12 @@
     (is (= ["Martin" "Katie"] (selectq-3 rick friends)))
 
     ;; literal set throws
-    (throws? ::m/select-validation-error ((selectq-2 #{rick}) friends))
-    (throws? ::m/select-validation-error (selectq-3 #{rick} friends))
+    (throws? ::m/invalid-bgp ((selectq-2 #{rick}) friends))
+    (throws? ::m/invalid-bgp (selectq-3 #{rick} friends))
 
     ;; bound arg set throws
-    (throws? ::m/select-validation-error (let [arg #{rick}] ((selectq-2 arg) friends)))
-    (throws? ::m/select-validation-error (let [arg #{rick}] (selectq-3 arg friends))))
+    (throws? ::m/invalid-bgp (let [arg #{rick}] ((selectq-2 arg) friends)))
+    (throws? ::m/invalid-bgp (let [arg #{rick}] (selectq-3 arg friends))))
 
   ;; construct validation
   (letfn [(constructq-2 [uri]
@@ -306,12 +306,12 @@
             friends)))
 
     ;; literal set throws
-    (throws? ::m/construct-validation-error ((constructq-2 #{rick}) friends))
-    (throws? ::m/construct-validation-error (constructq-3 #{rick} friends))
+    (throws? ::m/invalid-bgp ((constructq-2 #{rick}) friends))
+    (throws? ::m/invalid-bgp (constructq-3 #{rick} friends))
 
     ;; bound arg set throws
-    (throws? ::m/construct-validation-error (let [arg #{rick}] ((constructq-2 arg) friends)))
-    (throws? ::m/construct-validation-error (let [arg #{rick}] (constructq-3 arg friends))))
+    (throws? ::m/invalid-bgp (let [arg #{rick}] ((constructq-2 arg) friends)))
+    (throws? ::m/invalid-bgp (let [arg #{rick}] (constructq-3 arg friends))))
 
   ;; ask validation
   (letfn [(askq-1 [uri]
@@ -327,12 +327,12 @@
     (is (askq-2 rick friends))
 
     ;; literal set throws
-    (throws? ::m/ask-validation-error ((askq-1 #{rick}) friends))
-    (throws? ::m/ask-validation-error (askq-2 #{rick} friends))
+    (throws? ::m/invalid-bgp ((askq-1 #{rick}) friends))
+    (throws? ::m/invalid-bgp (askq-2 #{rick} friends))
 
     ;; bound arg set throws
-    (throws? ::m/ask-validation-error (let [arg #{rick}] ((askq-1 arg) friends)))
-    (throws? ::m/ask-validation-error (let [arg #{rick}] (askq-2 arg friends)))
+    (throws? ::m/invalid-bgp (let [arg #{rick}] ((askq-1 arg) friends)))
+    (throws? ::m/invalid-bgp (let [arg #{rick}] (askq-2 arg friends)))
 
     ;; no ?qvars are OK
     (is (let [col-uri rick] (m/ask [[col-uri foaf:knows martin]] friends)))))

--- a/test/grafter/matcha/alpha_test.clj
+++ b/test/grafter/matcha/alpha_test.clj
@@ -243,6 +243,7 @@
     (is (= ["Martin" "Katie"]
            (ricks-friends lotsa-data)))))
 
+
 (defmacro throws? [ex-type & body]
   `(is (try
          ~@body
@@ -377,24 +378,26 @@
       (is (= v1 v2)))))
 
 (deftest values-syntax-test
-  (is (= (let [people #{rick}]
+  (is (= #{"Martin" "Katie"}
+         (let [people #{rick}]
            (set
             (select [?name]
               [[?person foaf:knows ?o]
                [?o rdfs:label ?name]
                (values ?person people)]
-              friends)))
-         #{"Martin" "Katie"}))
-  (is (= (let [people #{rick katie}]
-           (set
-            (select [?name]
-              [[?person foaf:knows ?o]
-               [?o rdfs:label ?name]
-               (values ?person people)]
-              friends)))
-         #{"Martin" "Katie" "Julie"}))
+              friends)))))
 
-  (is (= (let [people #{rick katie}
+  (is (= #{"Martin" "Katie" "Julie"}
+         (let [people #{rick katie}]
+           (set
+            (select [?name]
+              [[?person foaf:knows ?o]
+               [?o rdfs:label ?name]
+               (values ?person people)]
+              friends)))))
+
+  (is (= #{"Julie"}
+         (let [people [rick katie]
                names #{"Julie"}]
            (set
             (select [?name]
@@ -402,8 +405,7 @@
                (values ?person people)
                [?o rdfs:label ?name]
                (values ?name names)]
-              friends)))
-         #{"Julie"}))
+              friends)))))
 
   (throws? ::m/invalid-values
            (let [people rick]
@@ -454,35 +456,37 @@
                 optional-friends)))
            #{[julie "Not a robot"]}))
     (is (= (set
+    (is (= #{[martin "Martin"] [katie "Katie"]}
+           (set
             (let [person rick]
               (select [?o ?name]
                 [[person foaf:knows ?o]
                  (optional [[?o rdfs:label ?name]])
                  (optional [[?o other:label ?name]])]
-                optional-friends)))
-           #{[martin "Martin"] [katie "Katie"]})))
+                optional-friends))))))
 
   (testing "OPTIONAL behaviour with VALUES"
-    (is (= (set
+    (is (=
+         #{[martin "Martin"] [katie "Katie"] [julie "Not a robot"]}
+         (set
             (let [people #{rick katie}]
               (select [?o ?name]
                 [[?person foaf:knows ?o]
                  (optional [[?o rdfs:label ?name]])
                  (optional [[?o other:label ?name]])
                  (values ?person people)]
-                optional-friends)))
-           #{[martin "Martin"] [katie "Katie"] [julie "Not a robot"]})))
+                optional-friends))))))
 
   (testing "Where optional thing is just not there"
-    (is (= (set
+    (is (= #{[martin "Martin"] [katie "Katie"]}
+           (set
             (let [people #{rick katie}]
               (select [?o ?name]
                 [[?person foaf:knows ?o]
                  [?o rdfs:label ?name]
                  (optional [[?o :who/am-i? ?dunno]])
                  (values ?person people)]
-                optional-friends)))
-           #{[martin "Martin"] [katie "Katie"]})))
+                optional-friends))))))
 
   (testing "How about some optionals in your optionals?"
     (is (= (set
@@ -494,8 +498,7 @@
                             (optional [[?name :name/backwards ?eman]
                                        (values ?name names)])])
                  (values ?person people)]
-                optional-friends)))
-           #{[martin "Nitram"] [katie '_0] [julie '_0]}))))
+                optional-friends)))))))
 
 (defmacro valid-syntax? [[op & args]]
   (let [argspec (:args (get (s/registry) (resolve-sym op)))]
@@ -503,6 +506,7 @@
 
 (def valid-syntax-symbol :hi-there)
 (def invalid-syntax-symbol [])
+
 (deftest macro-syntax-validation-test
   (let [people #{rick katie}
         names  #{"Martin"}]


### PR DESCRIPTION
Implement `VALUES` and `OPTIONAL` clauses in `select`, `construct` and `ask` macros.

* Further tighten syntax specs to validate symbols whose values we know at compile time
* Reduce deferred runtime checks to only scope-bound symbols

Fix: #9 
Fix: #11 