### PR TITLE
Implement new macros build and build-1

### DIFF
--- a/src/grafter/matcha/alpha.clj
+++ b/src/grafter/matcha/alpha.clj
@@ -344,31 +344,112 @@
                                                `(quote ~qv)) query-vars))]
     (walk/postwalk-replace replacements construct-pattern)))
 
-(defn group-subjects [solutions]
-  (if-let [subj-maps (seq (filter :grafter.rdf/uri solutions))]
+(def ^:private group-predicates-xf
+  (map (fn [v]
+         (apply merge-with
+                (fn [a b]
+                  (cond
+                    (set? a)
+                    (conj a b)
+                    :else
+                    (set [a b])))
+                v))))
+
+(def ^:private unsetify-grafter-uri
+  (map (fn [m]
+         (let [vs (:grafter.rdf/uri m)
+               v (if (set? vs)
+                   (first vs)
+                   vs)]
+           (assoc m :grafter.rdf/uri v)))))
+
+(defn group-subjects-for-construct [construct-pattern solutions]
+  (if (and (map? construct-pattern) (:grafter.rdf/uri construct-pattern))
     (into []
           (comp
-           (map (fn [v]
-                  (apply merge-with
-                         (fn [a b]
-                           (cond
-                             (set? a)
-                             (conj a b)
-                             :else
-                             (set [a b])))
-                         v)))
-           (map (fn [m]
-                  (let [vs (:grafter.rdf/uri m)
-                        v (if (set? vs)
-                            (first vs)
-                            vs)]
-                    (assoc m :grafter.rdf/uri v)))))
-          (vals (group-by :grafter.rdf/uri subj-maps)))
+           group-predicates-xf
+           unsetify-grafter-uri)
+          (vals (group-by :grafter.rdf/uri solutions)))
     solutions))
 
+(def ^:private clean-up-subject-map
+  "Removes any keys with unbound vars as values and flattens any sets
+  that have just one value into scalars."
+  (map (fn [e]
+         (reduce-kv (fn [m k v]
+                      (-> m
+                          (cond->
+                              (symbol? v)
+                              (dissoc k)
+
+                              (and (set? v) (= 1 (count v)))
+                              (assoc k (first v)))))
+                    e
+                    e))))
+
+(defn group-subjects-for-build [subject-k solutions]
+  (into []
+        (comp
+         group-predicates-xf
+         clean-up-subject-map)
+        (vals (group-by subject-k solutions))))
+
+(defmacro build
+  "Query a `db-or-idx` with `bgps` patterns, and return data grouped by
+  subject and predicates into resource object maps.
+
+  `subject` can be either a `?query-var` symbol used in the `bgps` or
+  a 2-tuple key value pair of `[:keyword ?query-var]`, in which case
+  `:keyword` will be the key used to identify the subject of the maps
+  in the response. If only `?query-var` and no `:keyword` is specified
+  then the default keyword of `:grafter.rdf/uri` is used.
+
+  NOTE: unlike `construct`, `build` will eliminate any unbound
+  variables from the response maps that may arrise from using an
+  optional.
+
+  If called with 3 arguments, returns a function of 1 argument: the `db-or-idx`,
+  which returns a sequence of results in the form of the `construct-pattern`.
+
+  If called with 4 arguments, queries the `db-or-idx` directly, returning a
+  sequence of results in the form of the `construct-pattern`."
+  ([subject construct-pattern bgps]
+   `(fn [db-or-idx#]
+      (build ~subject
+             ~construct-pattern ~bgps db-or-idx#)))
+  ([subject construct-pattern bgps db-or-idx]
+   (let [[subject-k subject-var] (if (symbol? subject)
+                                   [:grafter.rdf/uri subject]
+                                   subject)
+         pvars (cons subject-var (find-vars-in-tree construct-pattern))
+         pvarvec (vec pvars)]
+     `(->> ~(solve* 'build &env pvars bgps db-or-idx)
+           ;; create a sequence of {?var :value} binding maps for
+           ;; each solution.
+           (unify-solutions (quote ~pvarvec))
+           (replace-vars-with-vals ~(quote-query-vars pvarvec (merge {subject-k subject-var}
+                                                                     construct-pattern)))
+           (group-subjects-for-build ~subject-k)
+           seq))))
+
+(defmacro build-1
+  "Like `build` but returns only the first resource object.
+
+  NOTE: it is not lazy, so to make this efficient you should be
+  selective in your `bgps`."
+  ([subject-kv construct-pattern bgps]
+   `(fn [db-or-idx#]
+      (build ~subject-kv
+             ~construct-pattern ~bgps db-or-idx#)))
+  ([subject construct-pattern bgps db-or-idx]
+   `(first (build ~subject ~construct-pattern ~bgps ~db-or-idx))))
+
 (defmacro construct
-  "Query a `db-or-idx` with `bgps` patterns, and return data in the form of the
-  `construct-pattern`.
+  "NOTE: If you want to construct maps, you will likely be better
+  using `build` instead.
+
+  Query a `db-or-idx` with `bgps` patterns, and return data in the
+  form of the `construct-pattern`.
 
   If called with 2 arguments, returns a function of 1 argument: the `db-or-idx`,
   which returns a sequence of results in the form of the `construct-pattern`.
@@ -386,7 +467,7 @@
            ;; each solution.
            (unify-solutions (quote ~pvarvec))
            (replace-vars-with-vals ~(quote-query-vars pvarvec construct-pattern))
-           (group-subjects)
+           (group-subjects-for-construct (quote ~construct-pattern))
            seq))))
 
 (s/def ::construct-pattern any?)

--- a/test/grafter/matcha/alpha_test.clj
+++ b/test/grafter/matcha/alpha_test.clj
@@ -579,3 +579,61 @@
     (is (valid-syntax?
          (construct ?s
                     [[nil nil nil]])))))
+
+(deftest build-test
+  (testing "Sugared build"
+    (let [db [[:s :p :o]
+              [:s :p2 :o2]
+
+              [:s2 :p :o3]]
+
+          ret (build ?s
+                     {?p ?o}
+                     [[?s ?p ?o]]
+                     db)]
+
+      (is (= #{{:grafter.rdf/uri :s
+                :p :o
+                :p2 :o2}
+
+               {:grafter.rdf/uri :s2
+                :p :o3}}
+             (set ret))))
+
+    (testing "Optionals and predicate grouping"
+      (let [db [[:s :label "s"]
+                [:s :label "s another"]
+                [:s :p2 :o2]
+                [:s :optional "optional"]
+                [:s2 :label "s2"]
+                [:s2 :p2 :o2]]
+
+            ret (build ?s
+                       {:label ?label
+                        :optional ?opt}
+
+                       [[?s :label ?label]
+                        (grafter.matcha.alpha/optional [[?s :optional ?opt]])]
+                       db)]
+
+        (is (= #{{:grafter.rdf/uri :s,
+                  :label #{"s" "s another"},
+                  :optional "optional"}
+                 {:grafter.rdf/uri :s2, :label "s2"}}
+
+               (set ret)))))))
+
+(deftest build-1-test
+  (let [db [[:s :p :o]
+            [:s :p2 :o2]
+            [:s :p2 :o3]
+            [:s2 :p :o]
+            [:s2 :p2 :o2]]
+        ret (build-1 ?s
+                     {?p ?o}
+                     [(values ?s [:s])
+                      [?s ?p ?o]]
+                     db)]
+    (is (= {:grafter.rdf/uri :s, :p2 #{:o3 :o2}, :p :o}
+           ret))
+    ))

--- a/test/grafter/matcha/alpha_test.clj
+++ b/test/grafter/matcha/alpha_test.clj
@@ -581,24 +581,45 @@
                     [[nil nil nil]])))))
 
 (deftest build-test
-  (testing "Sugared build"
+  (testing "build"
     (let [db [[:s :p :o]
               [:s :p2 :o2]
 
-              [:s2 :p :o3]]
+              [:s2 :p :o3]]]
 
-          ret (build ?s
-                     {?p ?o}
-                     [[?s ?p ?o]]
-                     db)]
+      (testing "with unbound subject"
+        (let [ret (build ?s
+                         {?p ?o}
+                         [[?s ?p ?o]]
+                         db)]
+          (is (= #{{:grafter.rdf/uri :s
+                    :p :o
+                    :p2 :o2}
 
-      (is (= #{{:grafter.rdf/uri :s
-                :p :o
-                :p2 :o2}
+                   {:grafter.rdf/uri :s2
+                    :p :o3}}
+                 (set ret)))))
 
-               {:grafter.rdf/uri :s2
-                :p :o3}}
-             (set ret))))
+      (testing "with bound subject"
+        (let [subject :s
+              ret (build subject
+                         {?p ?o}
+                         [[subject ?p ?o]]
+                         db)]
+          (is (= #{{:grafter.rdf/uri :s
+                    :p :o
+                    :p2 :o2}}
+                 (set ret)))))
+
+      (testing "with hardcoded subject value"
+        (let [ret (build :s
+                         {?p ?o}
+                         [[:s ?p ?o]]
+                         db)]
+          (is (= #{{:grafter.rdf/uri :s
+                    :p :o
+                    :p2 :o2}}
+                 (set ret))))))
 
     (testing "Optionals and predicate grouping"
       (let [db [[:s :label "s"]


### PR DESCRIPTION
Main change is that the build macros fix various issues with
construct.

Most notably build macros:

- Fixes #24, by only grouping into sets where it's needed.
- Handles optionals better by hiding the presence of _0
  unbound variables, and removing any keys that may have them from
  the results.
- Closes #10 by implementing clearer grouping semantics

Also there's a small construct perf improvement for non grouping
queries due to a faster way to check whether we need to group. The
check was previously linear in results, now constant time.