### PR TITLE
Add clj-kondo 

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,1 @@
+{:linters {:unresolved-symbol {:exclude [(clojure.core.logic.pldb/db-rel)]}}}

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,13 @@
+name: Lint Clojure
+on: [pull_request]
+jobs:
+  clj-kondo:
+    name: runner / clj-kondo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: clj-kondo
+        uses: nnichols/clojure-lint-action@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review # Change reporter.

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -11,3 +11,4 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review # Change reporter.
+          level: warning

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 .cpcache
 /test-results/
 .clj-kondo/.cache
+/.lsp/

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 .hg/
 .cpcache
 /test-results/
+.clj-kondo/.cache

--- a/README.md
+++ b/README.md
@@ -315,10 +315,29 @@ solutions on a database of a million triples can be done on a laptop
 in less than 10 seconds.  Query time scaling seems to be roughly
 linear with the database size.
 
+## Avoiding clj-kondo lint errors with matcha macros
+
+Matcha exports some clj-kondo configuration which prevents clj-kondo
+warning about unbound variables when using the matcha query macros.
+
+You can import these configs into your project with the following
+command:
+
+```
+$ clj-kondo --copy-configs --dependencies --lint "$(clojure -Spath)"
+Imported config to .clj-kondo/grafter/matcha.alpha. To activate, add "grafter/matcha.alpha" to :config-paths in .clj-kondo/config.edn.
+```
+
+Then simply add the following to `.clj-kondo/config.edn`:
+
+```
+{:config-paths ["grafter/matcha.alpha"]}
+```
+
 ## Developing Matcha
 
-Matcha uses [`tools.build`](https://clojure.org/guides/tools_build) and 
-[`tools.deps`](https://clojure.org/guides/deps_and_cli) for builds, 
+Matcha uses [`tools.build`](https://clojure.org/guides/tools_build) and
+[`tools.deps`](https://clojure.org/guides/deps_and_cli) for builds,
 development and testing.
 
 The command:
@@ -336,16 +355,16 @@ $ clojure -T:build install
 
 can be used to build and install a jar into your local mvn repository.
 
-However for consuming local Matcha changes in local projects you are 
+However for consuming local Matcha changes in local projects you are
 usually better using `tools.deps` `:classpath-overrides`, or creating
 a branch and consuming via a `:git/url`.
 
 ## Deploying to Clojars
 
 For [deployments CircleCI is setup](https://github.com/Swirrl/matcha/blob/fafe7478ae605c4cb2a0253714c3bd286e1ca185/.circleci/config.yml#L46-L55)
-to automatically deploy tags of the form `vX.Y.Z` where `X.Y.Z` are 
-`major.minor.patch` numbers.  If you have permissions (i.e. you are 
-a Swirrl developer) the recommended workflow is to create a new 
+to automatically deploy tags of the form `vX.Y.Z` where `X.Y.Z` are
+`major.minor.patch` numbers.  If you have permissions (i.e. you are
+a Swirrl developer) the recommended workflow is to create a new
 release of the `main` branch in github with a tag that bumps the
 version number appropriately.
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {
- :paths ["src"]
+ :paths ["src" "resources"]
 
  :deps {org.clojure/core.logic {:mvn/version "1.0.0"}
         org.clojure/clojure {:mvn/version "1.10.3"}}

--- a/resources/clj-kondo.exports/grafter/matcha.alpha/config.edn
+++ b/resources/clj-kondo.exports/grafter/matcha.alpha/config.edn
@@ -1,0 +1,7 @@
+{ :linters {:unresolved-symbol {:exclude [(grafter.matcha.alpha/construct)
+                                          (grafter.matcha.alpha/construct-1)
+                                          (grafter.matcha.alpha/select)
+                                          (grafter.matcha.alpha/select-1)
+                                          (grafter.matcha.alpha/build)
+                                          (grafter.matcha.alpha/build-1)
+                                          (grafter.matcha.alpha/ask)]}}}

--- a/src/grafter/matcha/alpha.clj
+++ b/src/grafter/matcha/alpha.clj
@@ -1,6 +1,6 @@
 (ns grafter.matcha.alpha
   (:refer-clojure :exclude [==])
-  (:require [clojure.core.logic :as l :refer [fresh run*]]
+  (:require [clojure.core.logic :as l :refer [fresh run* ]]
             [clojure.core.logic.protocols :as lp]
             [clojure.core.logic.pldb :as pldb]
             [clojure.spec.alpha :as s]

--- a/src/grafter/matcha/alpha.clj
+++ b/src/grafter/matcha/alpha.clj
@@ -1,6 +1,6 @@
 (ns grafter.matcha.alpha
   (:refer-clojure :exclude [==])
-  (:require [clojure.core.logic :as l :refer [fresh run* ]]
+  (:require [clojure.core.logic :as l :refer [fresh]]
             [clojure.core.logic.protocols :as lp]
             [clojure.core.logic.pldb :as pldb]
             [clojure.spec.alpha :as s]
@@ -47,6 +47,8 @@
     grafter_2.rdf.protocols.OffsetDate
     (lp/-uninitialized [coll] coll)))
 
+(declare triple) ;; avoid clj-kondo linter warnings. The db-rel macro
+                 ;; below really defs the triple var.
 (pldb/db-rel triple ^:index subject ^:index predicate ^:index object)
 
 (defn triple-vector->idx-triple
@@ -99,7 +101,7 @@
     (select [?s ?p ?o]
       [[?s ?p ?o]
        (values ?s subjects)]))"
-  [binding bound-value]
+  [_binding _bound-value]
   (assert nil "`values` used not in a query block"))
 
 (defmacro optional
@@ -118,7 +120,7 @@
                            (values ?name names)])])]
     optional-friends)"
   {:style/indent :defn ::clause true}
-  [bgps]
+  [_bgps]
   (assert nil "`optional` used not in a query block"))
 
 (defn collection? [x]
@@ -247,7 +249,7 @@
     (reduce (partial merge-with merge)
             (map extract-row conformed-bgps))))
 
-(defn- solve* [qtype bound-vars pvars bgps db-or-idx]
+(defn- solve* [_qtype bound-vars pvars bgps db-or-idx]
   (let [conformed (s/conform ::bgps bgps)
         validation (extract-validation bound-vars conformed)]
     `(do


### PR DESCRIPTION
- [x] Add lint action https://github.com/nnichols/clojure-lint-action so PRs against matcha get automatically linted
- [x] Exports clj-kondo config for matcha macros so consumers can import them