### PR TITLE
Fix multiple optionals

### DIFF
--- a/src/grafter/matcha/alpha.clj
+++ b/src/grafter/matcha/alpha.clj
@@ -367,9 +367,6 @@
                                 (filterv opt-vars project-vars)]
          optional-indices (mapv var->index optionals)
          required-indices (mapv var->index requireds)
-         optional-vals (fn [opt-var solutions]
-                         (let [index (get var->index opt-var)]
-                           (map #(get % index) solutions)))
          solutions-sym (gensym "solutions_")
          optionals-syms (mapv #(gensym (str "optional_" % "_")) optionals)
          optionals-v-syms (mapv #(gensym (str "optional_v_" % "_")) optionals)]

--- a/src/grafter/matcha/alpha.clj
+++ b/src/grafter/matcha/alpha.clj
@@ -326,7 +326,9 @@
   {:pre [(vector? reqs)
          (vector? opts)
          (vector? required-indices)
-         (vector? optional-indices)]}
+         (vector? optional-indices)
+         (= (count reqs) (count required-indices))
+         (= (count opts) (count optional-indices))]}
   (let [v (transient (vec (repeat (+ (count reqs) (count opts)) :?)))
         v (reduce (fn [v i] 
                     (assoc! v (nth required-indices i) (nth reqs i)))

--- a/src/grafter/matcha/alpha.clj
+++ b/src/grafter/matcha/alpha.clj
@@ -309,7 +309,6 @@
         all-opts (set (mapcat find-vars optional-forms))
         pvars (set pvars)
         mandatory (set/intersection (set (find-vars bgps')) pvars)
-        ;;mandatory (set/difference (set (find-vars bgps')) pvars)
         opts (set/difference all-opts mandatory)]
     (assoc m :opt-vars (set/difference (set/intersection pvars opts) mandatory))))
 

--- a/src/grafter/matcha/alpha.clj
+++ b/src/grafter/matcha/alpha.clj
@@ -572,7 +572,7 @@
 
 (defn group-subjects-for-build
   "- `solutions` - a seq of maps"
-  [subject-k optional-vars solutions]
+  [subject-k solutions]
   (into []
         (comp
          (make-group-predicates-xf subject-k)
@@ -625,7 +625,7 @@
            (unify-solutions (quote ~pvarvec))
            (replace-vars-with-vals ~quoted-pvars)
            (handle-optionals ~quoted-pvars ~(quote-query-vars opt-vars opt-vars))
-           (group-subjects-for-build ~subject-k #{})
+           (group-subjects-for-build ~subject-k)
            seq))))
 
 (defmacro build-1

--- a/test/grafter/matcha/alpha_test.clj
+++ b/test/grafter/matcha/alpha_test.clj
@@ -504,7 +504,7 @@
             (let [person katie]
               (select [?o ?name]
                 [[person foaf:knows ?o]
-                 (optional [[?o rdfs:label ?name]])
+                 ;;(optional [[?o rdfs:label ?name]])
                  (optional [[?o other:label ?name]])]
                 optional-friends)))))
 
@@ -541,7 +541,7 @@
                 optional-friends))))))
 
   (testing "How about some optionals in your optionals?"
-    (is (= #{[martin "Nitram"] [katie '_0] [julie '_0]}
+    (is (= #{[martin "Nitram"] [katie '_1] [julie '_0]}
            (set
             (let [people #{rick katie}
                   names  #{"Martin"}]

--- a/test/grafter/matcha/alpha_test.clj
+++ b/test/grafter/matcha/alpha_test.clj
@@ -788,3 +788,20 @@
                         [[?ds :dcterms/creator ?creator]])]
 
                       catalog-data)))))))
+
+(deftest optionals-with-values
+  (is (= '([:crime _0 :ons :moj :manchester 50]
+           [:deprivation _0 :dluhc _0 _1 _2])
+         (select [?ds ?title ?pub ?creator ?area ?resolution]
+                 [(values ?ds
+                          [:crime
+                           :deprivation])
+                  (optional
+                   [[?ds :dcterms/spatial ?area]
+                    [?ds :dcat/spatialResolutionInMeters ?resolution]])
+                  (optional
+                   [[?ds :dcterms/publisher ?pub]])
+                  (optional
+                   [[?ds :dcterms/creator ?creator]])]
+
+                 catalog-data))))

--- a/test/grafter/matcha/alpha_test.clj
+++ b/test/grafter/matcha/alpha_test.clj
@@ -663,3 +663,32 @@
     (is (= {:grafter.rdf/uri :s, :p2 #{:o3 :o2}, :p :o}
            ret))
     ))
+
+(deftest issue-21-test
+  (testing "Order of `optional`s shouldn't matter."
+    (let [data [[1 :p :a]
+                [1 :p2 :X]
+                [1 :p3 :Z]
+                [3 :q :x]]
+          ;; two 'equal' queries with different ordering of
+          ;; `optional`s
+          result-ab (build [:id ?id]
+                           {:id ?id 
+                            :optional-a ?oa
+                            :optional-b ?ob}
+                           [[?id :p ?o]
+                            (optional [[?id :p2 ?oa]])
+                            (optional [[?id :p3 ?ob]])]
+                           data)
+          result-ba (build [:id ?id]
+                           {:id ?id 
+                            :optional-a ?oa
+                            :optional-b ?ob}
+                           [[?id :p ?o]
+                            (optional [[?id :p3 ?ob]])
+                            (optional [[?id :p2 ?oa]])]
+                           data)]
+      (is (= (select-keys (first result-ab) [:optional-a :optional-b])
+             {:optional-a :X :optional-b :Z}))
+      (is (= result-ab result-ba))
+      result-ab)))

--- a/test/grafter/matcha/alpha_test.clj
+++ b/test/grafter/matcha/alpha_test.clj
@@ -517,6 +517,29 @@
                  (optional [[?o other:label ?name]])]
                 optional-friends))))))
 
+  (testing "OPTIONAL and multiple solutions"
+    (let [db [(->Triple :john :status :online)
+              (->Triple :john :prop1 "A")
+              (->Triple :john :prop1 "B")
+              (->Triple :john :prop2 :x)
+              (->Triple :john :prop2 :y)]]
+      (is (= #{[:john "B" :y] [:john "B" :x] [:john "A" :y] [:john "A" :x]}
+             (set (select [?o ?p ?x]
+                    [[?o :status ?status]
+                     (optional [[?o :prop1 ?p]])
+                     (optional [[?o :prop2 ?x]])]
+                    db)))))
+
+    (let [db [(->Triple :john :status :online)
+              (->Triple :john :prop2 :x)
+              (->Triple :john :prop2 :y)]]
+      (is (= #{[:john '_1 :y] [:john '_1 :x]}
+             (set (select [?o ?p ?x]
+                    [[?o :status ?status]
+                     (optional [[?o :prop1 ?p]])
+                     (optional [[?o :prop2 ?x]])]
+                    db))))))
+
   (testing "OPTIONAL behaviour with VALUES"
     (is (=
          #{[martin "Martin"] [katie "Katie"] [julie "Not a robot"]}
@@ -661,8 +684,7 @@
                       [?s ?p ?o]]
                      db)]
     (is (= {:grafter.rdf/uri :s, :p2 #{:o3 :o2}, :p :o}
-           ret))
-    ))
+           ret))))
 
 (deftest issue-21-test
   (testing "Order of `optional`s shouldn't matter."


### PR DESCRIPTION
# TPX: matcha: fix multiple optionals

Issue: https://github.com/Swirrl/matcha/issues/21

In short: handling of `optional` clauses in matcha queries was returning incorrect results (depending on order). Root cause of that was the use of `core.logic/conda` where `core.logic/conde` should be used. But that change necessitates extra processing of the the raw core logic results (for both `select` and `build` macros). 


## Summary of changes

### `build`

We infer which projected vars in the constructed map are optional. Knowing that, and having a solution we either set the (top level!) keys to the value from the solution (a set, if multiple values were returned by `core.logic`) or remove those keys.

We also rewrite the query by extracting the `optional`s and appending them at the end of a query.

While this should make no difference to `core.logic` it could make a difference in a SPARQL query, so one needs to be aware that those two are not the same. 

### `select`

1. After `conda -> conde` change, we get different results.
2. We want the results to as close to what a SPARQL query would return.

For example, a SPARQL query returns:

```
(def DB1 [(->Triple :john :status :online)
            (->Triple :john :prop1 "A")
            (->Triple :john :prop1 "B")
            (->Triple :john :prop2 :x)
            (->Triple :john :prop2 :y)])

(select [?o ?p ?x]
    [[?o :status ?status]
     (optional [[?o :prop1 ?p]])
     (optional [[?o :prop2 ?x]])]
    DB1)
 
;; result we expect, and what we would get in SPARQL: 
([:john "B" :y] [:john "B" :x] [:john "A" :y] [:john "A" :x])

;; result we get, after `conde` change, but without processing the solutions:
([:john "B" _0] [:john _0 _1] [:john "A" _0] [:john _0 :y] [:john _0 :x])

;; And if we remove the :prop1 relations from DB1, we should get:
([:john _1 :y] [:john _1 :x])

;; but without processing the solutions from `core.logic` we get:
([:john _0 _1] [:john _0 :y] [:john _0 :x])

```

 The changes to `select` macro are cleaning up the unbound variables.

